### PR TITLE
Allow node versions greater than 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A wrapper which can be used to interact with Binance's API. Entirely developed in TypeScript.",
     "main": "build/index.js",
     "engines": {
-        "node": "^8.4.0"
+        "node": ">=8.4.0"
     },
     "scripts": {
         "build": "tsc && cp index.d.ts build",


### PR DESCRIPTION
Is there any reason to limit this library to just node 8?